### PR TITLE
Adding prompt and delayed nuFiss macroResponses

### DIFF
--- a/SharedModules/endfConstants.f90
+++ b/SharedModules/endfConstants.f90
@@ -96,13 +96,15 @@ module endfConstants
                                   anyCapture    = -201, &
                                   anyFission    = -118
 
-  ! List of Fake MT numbers for macroscopic XSs. Stolen from Serpent
-  integer(shortInt),parameter  :: macroTotal     = -1 ,&
-                                  macroCapture   = -2 ,&
-                                  macroEscatter  = -3 ,&
-                                  macroIEscatter = -4 ,&
-                                  macroFission   = -6 ,&
-                                  macroNuFission = -7
+  ! List of Fake MT numbers for macroscopic XSs. Partially stolen from Serpent
+  integer(shortInt),parameter  :: macroTotal            = -1 ,&
+                                  macroCapture          = -2 ,&
+                                  macroEscatter         = -3 ,&
+                                  macroIEscatter        = -4 ,&
+                                  macroFission          = -6 ,&
+                                  macroNuFission        = -7 ,&
+                                  macroPromptNuFission  = -8 ,&
+                                  macroDelayedNuFission = -9
 
   ! List of Macro MT numbers for macroscopic XSs. Unique to SCONE (not from Serpent)
   integer(shortInt), parameter :: macroAllScatter = -20 ,&

--- a/Tallies/TallyResponses/macroResponse_class.f90
+++ b/Tallies/TallyResponses/macroResponse_class.f90
@@ -88,14 +88,13 @@ contains
 
     ! Check that MT number is valid
     select case(MT)
-      case(macroTotal, macroCapture, macroFission, macroNuFission, macroAbsorbtion)
+    case(macroTotal, macroCapture, macroFission, macroNuFission, macroAbsorbtion, &
+         macroEscatter, macroIEscatter, macroPromptNuFission, macroDelayedNuFission)
         ! Do nothing. MT is Valid
-
-      case(macroEscatter)
-        call fatalError(Here,'Macroscopic Elastic scattering is not implemented yet')
 
       case default
         call fatalError(Here,'Unrecognised MT number: '// numToChar(self % MT))
+
     end select
 
     ! Load MT
@@ -122,15 +121,16 @@ contains
     val = ZERO
 
     ! Return 0.0 if particle is not neutron
-    if(p % type /= P_NEUTRON) return
+    if (p % type /= P_NEUTRON) return
 
     ! Get pointer to active material data
     mat => neutronMaterial_CptrCast(xsData % getMaterial(p % matIdx()))
 
     ! Return if material is not a neutronMaterial
-    if(.not.associated(mat)) return
+    if (.not.associated(mat)) return
 
     call mat % getMacroXSs(xss, p)
+
     val = xss % get(self % MT)
 
   end function get


### PR DESCRIPTION
Few changes to add the option of prompt and delayed nu fission to the macroResponse:

- adding a prompt nu fission entry to the xss packages
- storing the values of prompt nu fission in aceNeutronNuclide during initialisation
- retrieving the values of prompt nu fission in the procedures to calculate the microscopic xss in aceNeutronNuclide

I haven't compared the results against Serpent because doesn't seem to have the option to tally prompt and delayed fissions separately, but results look sensible.